### PR TITLE
Allow Policy Test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: lint
+name: ci
 
 on: [push, pull_request]
 

--- a/test/allowPolicy.spec.ts
+++ b/test/allowPolicy.spec.ts
@@ -1,0 +1,109 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
+import { expect } from 'chai'
+import { ZeroAddress } from 'ethers'
+import { ethers } from 'hardhat'
+
+import { createConfiguration, createSafe, execTransaction, randomAddress, SafeOperation } from '../src/utils'
+import { deploySafePolicyGuard, deploySafeContracts, deployAllowPolicy } from './deploy'
+
+describe('AllowPolicy', function () {
+  async function fixture() {
+    const [, owner, other] = await ethers.getSigners()
+
+    // Deploy the SafePolicyGuard contract
+    const { safePolicyGuard } = await deploySafePolicyGuard()
+
+    // Deploy the Safe contracts
+    const { safeProxyFactory, safe: safeSingleton } = await deploySafeContracts()
+    const safe = await createSafe({
+      owner,
+      guard: ZeroAddress, // No guard at this point
+      saltNonce: BigInt(0x2),
+      safeProxyFactory,
+      singleton: safeSingleton
+    })
+
+    // Deploy AllowPolicy contract
+    const { allowPolicy } = await deployAllowPolicy()
+
+    // Deploy Test Access Selector
+    const AccessSelectorFactory = await ethers.getContractFactory('TestAccessSelector')
+    const accessSelector = await AccessSelectorFactory.deploy()
+
+    return { owner, other, safePolicyGuard, safe, allowPolicy, accessSelector }
+  }
+
+  describe('Integration with SafePolicyGuard', function () {
+    it('Should allow particular transaction when configured through allow policy', async function () {
+      const { owner, safePolicyGuard, safe, allowPolicy } = await loadFixture(fixture)
+
+      const target = randomAddress()
+      const value = ethers.parseEther('1')
+
+      const configurations = [createConfiguration({ target, policy: await allowPolicy.getAddress() })]
+
+      // Configure the allow policy to send some value to the target
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations]),
+        operation: SafeOperation.Call
+      })
+
+      // Enable the guard on safe
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()]),
+        operation: SafeOperation.Call
+      })
+
+      // Send some ETH from owner to the safe for next transaction
+      await owner.sendTransaction({
+        to: await safe.getAddress(),
+        value
+      })
+
+      // Try to execute the particular transaction
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: target,
+        value
+      })
+
+      // Verify the transaction was executed by checking the target's balance
+      expect(await ethers.provider.getBalance(target)).to.equal(value)
+    })
+
+    it('Should not allow any transaction which is not configured through allow policy', async function () {
+      const { owner, safe, safePolicyGuard } = await loadFixture(fixture)
+
+      const target = randomAddress()
+      const value = ethers.parseEther('1')
+
+      // Enable the guard on safe
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()]),
+        operation: SafeOperation.Call
+      })
+
+      // Try to execute a random transaction
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: target,
+          value
+        })
+      )
+        .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
+        .withArgs(ZeroAddress)
+    })
+  })
+})

--- a/test/safePolicyGuard.spec.ts
+++ b/test/safePolicyGuard.spec.ts
@@ -29,7 +29,7 @@ describe('SafePolicyGuard', function () {
     const safe = await createSafe({
       owner,
       guard: ZeroAddress, // No guard at this point
-      saltNonce: BigInt(0xbeef),
+      saltNonce: BigInt(0x1),
       safeProxyFactory,
       singleton: safeSingleton
     })
@@ -164,8 +164,9 @@ describe('SafePolicyGuard', function () {
         configuration[0].operation
       )
 
-      // Check that the access is 0 and policy is ZeroAddress
-      expect(initialAccess).to.equal(0)
+      // Check that the access is fallback access and policy is ZeroAddress
+      const expectedFallbackAccess = await accessSelector.createFallback(configuration[0].operation)
+      expect(initialAccess).to.equal(expectedFallbackAccess)
       expect(initialPolicy).to.equal(ZeroAddress)
 
       // Call the configure immediately function on safe using execTransaction helper function
@@ -832,7 +833,7 @@ describe('SafePolicyGuard', function () {
         operation: SafeOperation.Call
       })
 
-      // Do some transaction on safe using execTransaction helper function
+      // Try to execute a transaction that is not configured
       await expect(
         execTransaction({
           owners: [owner],
@@ -873,7 +874,7 @@ describe('SafePolicyGuard', function () {
         operation: SafeOperation.Call
       })
 
-      // Do some transaction on safe using the module
+      // Try to execute a transaction that is not configured through the module
       await expect(testModule.executeTx(await safe.getAddress(), randomAddress(), 0, '0x', SafeOperation.Call))
         .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
         .withArgs(ZeroAddress)


### PR DESCRIPTION
TLDR:
- Added some basic test for Allow Policy
- Small changes in other files

This pull request introduces significant updates to the CI workflow and testing suite, focusing on improving test coverage for the `AllowPolicy` and `SafePolicyGuard` functionalities. Key changes include renaming the CI workflow, adding a new test suite for `AllowPolicy`, and enhancing existing tests for `SafePolicyGuard` with more precise assertions and descriptions.

### CI Workflow Update:
* Renamed the workflow in `.github/workflows/ci.yml` from "lint" to "ci" to better reflect its purpose.

### New Test Suite for `AllowPolicy`:
* Added a comprehensive test suite in `test/allowPolicy.spec.ts` to validate the integration of `AllowPolicy` with `SafePolicyGuard`. This includes:
  - Verifying that transactions configured through `AllowPolicy` are permitted.
  - Ensuring that transactions not configured through `AllowPolicy` are denied with appropriate errors.

### Enhancements to `SafePolicyGuard` Tests:
* Updated the `saltNonce` in `createSafe` calls to ensure consistent test setup.
* Refined assertions to verify fallback access creation when no specific access is configured.
* Improved test descriptions to clarify the behavior being tested:
  - Changed comments to specify that unconfigured transactions should fail. [[1]](diffhunk://#diff-e64147aac41e73953d455d654d86f980415e855f29db5503a3f31e2008e23fb4L835-R836) [[2]](diffhunk://#diff-e64147aac41e73953d455d654d86f980415e855f29db5503a3f31e2008e23fb4L876-R877)