### PR TITLE
ERC20 Approve Test

### DIFF
--- a/test/allowPolicy.spec.ts
+++ b/test/allowPolicy.spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai'
 import { ZeroAddress } from 'ethers'
 import { ethers } from 'hardhat'
 
-import { createConfiguration, createSafe, execTransaction, randomAddress, SafeOperation } from '../src/utils'
+import { createConfiguration, createSafe, execTransaction, randomAddress } from '../src/utils'
 import { deploySafePolicyGuard, deploySafeContracts, deployAllowPolicy } from './deploy'
 
 describe('AllowPolicy', function () {
@@ -47,8 +47,7 @@ describe('AllowPolicy', function () {
         owners: [owner],
         safe,
         to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations]),
-        operation: SafeOperation.Call
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
       })
 
       // Enable the guard on safe
@@ -56,8 +55,7 @@ describe('AllowPolicy', function () {
         owners: [owner],
         safe,
         to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()]),
-        operation: SafeOperation.Call
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
       })
 
       // Send some ETH from owner to the safe for next transaction
@@ -89,8 +87,7 @@ describe('AllowPolicy', function () {
         owners: [owner],
         safe,
         to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()]),
-        operation: SafeOperation.Call
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
       })
 
       // Try to execute a random transaction

--- a/test/erc20ApprovePolicy.spec.ts
+++ b/test/erc20ApprovePolicy.spec.ts
@@ -1,0 +1,326 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
+import { expect } from 'chai'
+import { ZeroAddress } from 'ethers'
+import { ethers } from 'hardhat'
+
+import { createConfiguration, createSafe, execTransaction, randomAddress, SafeOperation } from '../src/utils'
+import { deploySafeContracts, deploySafePolicyGuard, deployERC20ApprovePolicy, deployTestERC20Token } from './deploy'
+
+describe('ERC20ApprovePolicy', function () {
+  async function fixture() {
+    const [, owner, spender, other] = await ethers.getSigners()
+
+    // Deploy the SafePolicyGuard contract
+    const { safePolicyGuard } = await deploySafePolicyGuard()
+
+    // Deploy the Safe contracts
+    const { safeProxyFactory, safe: safeSingleton } = await deploySafeContracts()
+    const safe = await createSafe({
+      owner,
+      guard: ZeroAddress, // No guard at this point
+      saltNonce: BigInt(0x3),
+      safeProxyFactory,
+      singleton: safeSingleton
+    })
+
+    // Deploy ERC20ApprovePolicy contract
+    const { erc20ApprovePolicy } = await deployERC20ApprovePolicy()
+
+    // Deploy Test ERC20 Token contract
+    const { token } = await deployTestERC20Token()
+
+    return {
+      owner,
+      spender,
+      other,
+      safe,
+      safePolicyGuard,
+      erc20ApprovePolicy,
+      token
+    }
+  }
+
+  describe('Integration with SafePolicyGuard', function () {
+    it('Should allow approve transaction when spender is configured', async function () {
+      const { owner, safePolicyGuard, safe, erc20ApprovePolicy, token } = await loadFixture(fixture)
+
+      const spender = randomAddress()
+      const amount = ethers.parseEther('100')
+
+      // Configure the ERC20 approve policy
+      const spenderData = [
+        {
+          spender,
+          allowed: true
+        }
+      ]
+
+      const configurations = [
+        createConfiguration({
+          target: await token.getAddress(),
+          selector: token.interface.getFunction('approve').selector,
+          policy: await erc20ApprovePolicy.getAddress(),
+          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address spender, bool allowed)[]'], [spenderData])
+        })
+      ]
+
+      // Configure the policy
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
+      })
+
+      // Enable the guard on safe
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+      })
+
+      // Verify there was no previous approval
+      expect(await token.allowance(await safe.getAddress(), spender)).to.equal(0)
+
+      // Try to execute the approve transaction
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await token.getAddress(),
+        data: token.interface.encodeFunctionData('approve', [spender, amount])
+      })
+
+      // Verify the approval was successful
+      expect(await token.allowance(await safe.getAddress(), spender)).to.equal(amount)
+    })
+
+    it('Should not allow approve transaction when spender is not configured', async function () {
+      const { owner, safePolicyGuard, safe, erc20ApprovePolicy, token } = await loadFixture(fixture)
+
+      const spender = randomAddress()
+      const amount = ethers.parseEther('100')
+
+      // Configure the ERC20 approve policy with no signer
+      const spenderData = [
+        {
+          spender: ZeroAddress,
+          allowed: false
+        }
+      ]
+
+      const configurations = [
+        createConfiguration({
+          target: await token.getAddress(),
+          selector: token.interface.getFunction('approve').selector,
+          policy: await erc20ApprovePolicy.getAddress(),
+          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address spender, bool allowed)[]'], [spenderData])
+        })
+      ]
+
+      // Configure the policy
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
+      })
+
+      // Enable the guard on safe
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+      })
+
+      // Try to execute the approve transaction
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: await token.getAddress(),
+          data: token.interface.encodeFunctionData('approve', [spender, amount])
+        })
+      ).to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
+    })
+
+    it('Should not allow non-approve transactions', async function () {
+      const { owner, safePolicyGuard, safe, erc20ApprovePolicy, token } = await loadFixture(fixture)
+
+      const spender = randomAddress()
+      const amount = ethers.parseEther('100')
+
+      // Configure the ERC20 approve policy
+      const spenderData = [
+        {
+          spender,
+          allowed: true
+        }
+      ]
+
+      const configurations = [
+        createConfiguration({
+          target: await token.getAddress(),
+          selector: token.interface.getFunction('approve').selector,
+          policy: await erc20ApprovePolicy.getAddress(),
+          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address spender, bool allowed)[]'], [spenderData])
+        })
+      ]
+
+      // Configure the policy
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
+      })
+
+      // Enable the guard on safe
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+      })
+
+      // Try to execute a transfer transaction (non-approve)
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: await token.getAddress(),
+          data: token.interface.encodeFunctionData('transfer', [spender, amount])
+        })
+      ).to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
+    })
+
+    it('Should allow zero amount approvals even for unconfigured spenders', async function () {
+      const { owner, safePolicyGuard, safe, erc20ApprovePolicy, token } = await loadFixture(fixture)
+
+      const spender = randomAddress()
+      const amount = ethers.parseEther('1')
+
+      // Configure the ERC20 approve policy with a different spender
+      const spenderData = [
+        {
+          spender: ZeroAddress,
+          allowed: false
+        }
+      ]
+
+      const configurations = [
+        createConfiguration({
+          target: await token.getAddress(),
+          selector: token.interface.getFunction('approve').selector,
+          policy: await erc20ApprovePolicy.getAddress(),
+          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address spender, bool allowed)[]'], [spenderData])
+        })
+      ]
+
+      // Approve the amount for the configured spender in Safe
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await token.getAddress(),
+        data: token.interface.encodeFunctionData('approve', [spender, amount])
+      })
+
+      // Verify the approval was successful
+      expect(await token.allowance(await safe.getAddress(), spender)).to.equal(amount)
+
+      // Configure the policy
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
+      })
+
+      // Enable the guard on safe
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+      })
+
+      // Try to execute the zero amount approve transaction
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await token.getAddress(),
+        data: token.interface.encodeFunctionData('approve', [spender, 0])
+      })
+
+      // Verify the approval was successful
+      expect(await token.allowance(await safe.getAddress(), spender)).to.equal(0)
+    })
+  })
+  describe('Policy Configuration', function () {
+    it('Should only be able to configure ERC20 approve transactions', async function () {
+      const { owner, safePolicyGuard, safe, erc20ApprovePolicy, token } = await loadFixture(fixture)
+
+      // Configure the ERC20 approve policy
+      const spenderData = [
+        {
+          spender: randomAddress(),
+          allowed: true
+        }
+      ]
+
+      // Trying to configure a non-approve transaction
+      const configurations = [
+        createConfiguration({
+          target: await token.getAddress(),
+          selector: token.interface.getFunction('transfer').selector, // Non-approve function
+          policy: await erc20ApprovePolicy.getAddress(),
+          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address spender, bool allowed)[]'], [spenderData])
+        })
+      ]
+
+      // Configure the policy
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: await safePolicyGuard.getAddress(),
+          data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
+        })
+      ).to.be.revertedWithCustomError(erc20ApprovePolicy, 'InvalidSelector')
+    })
+
+    it('Should only be able to configure CALL operations', async function () {
+      const { owner, safePolicyGuard, safe, erc20ApprovePolicy, token } = await loadFixture(fixture)
+
+      // Configure the ERC20 approve policy
+      const spenderData = [
+        {
+          spender: randomAddress(),
+          allowed: true
+        }
+      ]
+
+      // Trying to configure a non-approve transaction
+      const configurations = [
+        createConfiguration({
+          target: await token.getAddress(),
+          selector: token.interface.getFunction('approve').selector,
+          policy: await erc20ApprovePolicy.getAddress(),
+          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address spender, bool allowed)[]'], [spenderData]),
+          operation: SafeOperation.DelegateCall // Non-CALL operation
+        })
+      ]
+
+      // Configure the policy
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: await safePolicyGuard.getAddress(),
+          data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
+        })
+      ).to.be.revertedWithCustomError(erc20ApprovePolicy, 'InvalidOperation')
+    })
+  })
+})

--- a/test/safePolicyGuard.spec.ts
+++ b/test/safePolicyGuard.spec.ts
@@ -98,8 +98,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configuration]),
-        operation: SafeOperation.Call
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configuration])
       })
 
       // Check if the configuration is set
@@ -144,8 +143,7 @@ describe('SafePolicyGuard', function () {
           owners: [owner],
           safe,
           to: await safePolicyGuard.getAddress(),
-          data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configuration]),
-          operation: SafeOperation.Call
+          data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configuration])
         })
       ).to.be.revertedWithCustomError(safePolicyGuard, 'PolicyConfigurationFailed') // Actual error is `PolicyConfigurationFailed`
     })
@@ -174,8 +172,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configuration]),
-        operation: SafeOperation.Call
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configuration])
       })
 
       // Check if the configuration is set
@@ -227,8 +224,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configuration]),
-        operation: SafeOperation.Call
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configuration])
       })
 
       // Check if the configuration is set
@@ -270,8 +266,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()]),
-        operation: SafeOperation.Call
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
       })
 
       // Call the configure immediately function on safe using execTransaction helper function
@@ -280,8 +275,7 @@ describe('SafePolicyGuard', function () {
           owners: [owner],
           safe,
           to: await safePolicyGuard.getAddress(),
-          data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configuration]),
-          operation: SafeOperation.Call
+          data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configuration])
         })
       )
         .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
@@ -313,8 +307,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot]),
-        operation: SafeOperation.Call
+        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot])
       })
 
       // Check if the configuration request is set
@@ -345,8 +338,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()]),
-        operation: SafeOperation.Call
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
       })
 
       // Getting the timestamp of the configuration request
@@ -357,8 +349,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot]),
-        operation: SafeOperation.Call
+        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot])
       })
 
       // Check if the configuration request is set
@@ -389,8 +380,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot]),
-        operation: SafeOperation.Call
+        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot])
       })
 
       // Call the request configuration function again on safe using execTransaction helper function
@@ -399,8 +389,7 @@ describe('SafePolicyGuard', function () {
           owners: [owner],
           safe,
           to: await safePolicyGuard.getAddress(),
-          data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot]),
-          operation: SafeOperation.Call
+          data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot])
         })
       ).to.be.revertedWithCustomError(safePolicyGuard, 'RootAlreadyConfigured') // Actual error is `RootAlreadyConfigured`
     })
@@ -429,8 +418,7 @@ describe('SafePolicyGuard', function () {
           owners: [owner],
           safe,
           to: await safePolicyGuard.getAddress(),
-          data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot]),
-          operation: SafeOperation.Call
+          data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot])
         })
       )
         .to.emit(safePolicyGuard, 'RootConfigured')
@@ -459,8 +447,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot]),
-        operation: SafeOperation.Call
+        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot])
       })
 
       // Increase the time to the delay
@@ -471,8 +458,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('applyConfiguration', [configuration]),
-        operation: SafeOperation.Call
+        data: safePolicyGuard.interface.encodeFunctionData('applyConfiguration', [configuration])
       })
 
       // Check if the configuration is set
@@ -515,8 +501,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()]),
-        operation: SafeOperation.Call
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
       })
 
       // Call the request configuration function on safe using execTransaction helper function
@@ -524,8 +509,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot]),
-        operation: SafeOperation.Call
+        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot])
       })
 
       // Increase the time to the delay
@@ -536,8 +520,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('applyConfiguration', [configuration]),
-        operation: SafeOperation.Call
+        data: safePolicyGuard.interface.encodeFunctionData('applyConfiguration', [configuration])
       })
 
       // Check if the configuration is set
@@ -578,8 +561,7 @@ describe('SafePolicyGuard', function () {
           owners: [owner],
           safe,
           to: await safePolicyGuard.getAddress(),
-          data: safePolicyGuard.interface.encodeFunctionData('applyConfiguration', [configuration]),
-          operation: SafeOperation.Call
+          data: safePolicyGuard.interface.encodeFunctionData('applyConfiguration', [configuration])
         })
       ).to.be.revertedWithCustomError(safePolicyGuard, 'RootNotConfigured') // Actual error is `RootNotConfigured`
     })
@@ -604,8 +586,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot]),
-        operation: SafeOperation.Call
+        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot])
       })
 
       // Call the apply configuration function on safe using execTransaction helper function
@@ -614,8 +595,7 @@ describe('SafePolicyGuard', function () {
           owners: [owner],
           safe,
           to: await safePolicyGuard.getAddress(),
-          data: safePolicyGuard.interface.encodeFunctionData('applyConfiguration', [configuration]),
-          operation: SafeOperation.Call
+          data: safePolicyGuard.interface.encodeFunctionData('applyConfiguration', [configuration])
         })
       ).to.be.revertedWithCustomError(safePolicyGuard, 'RootConfigurationPending') // Actual error is `RootConfigurationPending`
     })
@@ -640,8 +620,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot]),
-        operation: SafeOperation.Call
+        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot])
       })
 
       // Increase the time to the delay
@@ -653,8 +632,7 @@ describe('SafePolicyGuard', function () {
           owners: [owner],
           safe,
           to: await safePolicyGuard.getAddress(),
-          data: safePolicyGuard.interface.encodeFunctionData('applyConfiguration', [configuration]),
-          operation: SafeOperation.Call
+          data: safePolicyGuard.interface.encodeFunctionData('applyConfiguration', [configuration])
         })
       )
         .to.emit(safePolicyGuard, 'PolicyConfirmed')
@@ -690,8 +668,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot]),
-        operation: SafeOperation.Call
+        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot])
       })
 
       // Call the invalidate root function on safe using execTransaction helper function
@@ -699,8 +676,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('invalidateRoot', [configurationRoot]),
-        operation: SafeOperation.Call
+        data: safePolicyGuard.interface.encodeFunctionData('invalidateRoot', [configurationRoot])
       })
 
       // Check if the configuration is invalidated
@@ -731,8 +707,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()]),
-        operation: SafeOperation.Call
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
       })
 
       // Call the request configuration function on safe using execTransaction helper function
@@ -740,8 +715,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot]),
-        operation: SafeOperation.Call
+        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot])
       })
 
       // Call the invalidate root function on safe using execTransaction helper function
@@ -749,8 +723,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('invalidateRoot', [configurationRoot]),
-        operation: SafeOperation.Call
+        data: safePolicyGuard.interface.encodeFunctionData('invalidateRoot', [configurationRoot])
       })
 
       // Check if the configuration is invalidated
@@ -773,8 +746,7 @@ describe('SafePolicyGuard', function () {
           owners: [owner],
           safe,
           to: await safePolicyGuard.getAddress(),
-          data: safePolicyGuard.interface.encodeFunctionData('invalidateRoot', [configurationRoot]),
-          operation: SafeOperation.Call
+          data: safePolicyGuard.interface.encodeFunctionData('invalidateRoot', [configurationRoot])
         })
       )
         .to.be.revertedWithCustomError(safePolicyGuard, 'RootNotConfigured')
@@ -801,8 +773,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot]),
-        operation: SafeOperation.Call
+        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot])
       })
 
       // Call the invalidate root function on safe using execTransaction helper function
@@ -811,8 +782,7 @@ describe('SafePolicyGuard', function () {
           owners: [owner],
           safe,
           to: await safePolicyGuard.getAddress(),
-          data: safePolicyGuard.interface.encodeFunctionData('invalidateRoot', [configurationRoot]),
-          operation: SafeOperation.Call
+          data: safePolicyGuard.interface.encodeFunctionData('invalidateRoot', [configurationRoot])
         })
       )
         .to.emit(safePolicyGuard, 'RootInvalidated')
@@ -829,8 +799,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()]),
-        operation: SafeOperation.Call
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
       })
 
       // Try to execute a transaction that is not configured
@@ -838,9 +807,7 @@ describe('SafePolicyGuard', function () {
         execTransaction({
           owners: [owner],
           safe,
-          to: randomAddress(),
-          data: '0x',
-          operation: SafeOperation.Call
+          to: randomAddress()
         })
       )
         .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
@@ -861,8 +828,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('enableModule', [await testModule.getAddress()]),
-        operation: SafeOperation.Call
+        data: safe.interface.encodeFunctionData('enableModule', [await testModule.getAddress()])
       })
 
       // Enable the guard on safe as ModuleGuard (Using Safe v1.5.0)
@@ -870,8 +836,7 @@ describe('SafePolicyGuard', function () {
         owners: [owner],
         safe,
         to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setModuleGuard', [await safePolicyGuard.getAddress()]),
-        operation: SafeOperation.Call
+        data: safe.interface.encodeFunctionData('setModuleGuard', [await safePolicyGuard.getAddress()])
       })
 
       // Try to execute a transaction that is not configured through the module


### PR DESCRIPTION
## TLDR:
- Added ERC20 Approve Test
- Small refactoring of the tests

## LLM Description

This pull request includes updates to multiple test files, primarily focusing on simplifying transaction configurations by removing the `operation` parameter where it was previously set to `SafeOperation.Call`. Additionally, a new test suite for the `ERC20ApprovePolicy` was introduced, covering various scenarios for ERC20 token approval policies.

### Simplification of transaction configurations:
* Removed the `operation` parameter (`SafeOperation.Call`) from transaction configurations in `test/allowPolicy.spec.ts` to streamline the code. [[1]](diffhunk://#diff-163dd40c369a804eea77537773f09f8acca48158a52bfa48074217baa0ab2785L50-R58) [[2]](diffhunk://#diff-163dd40c369a804eea77537773f09f8acca48158a52bfa48074217baa0ab2785L92-R90)
* Similar changes were made in `test/safePolicyGuard.spec.ts`, removing `operation: SafeOperation.Call` across multiple test cases to simplify transaction calls. [[1]](diffhunk://#diff-e64147aac41e73953d455d654d86f980415e855f29db5503a3f31e2008e23fb4L101-R101) [[2]](diffhunk://#diff-e64147aac41e73953d455d654d86f980415e855f29db5503a3f31e2008e23fb4L147-R146) [[3]](diffhunk://#diff-e64147aac41e73953d455d654d86f980415e855f29db5503a3f31e2008e23fb4L177-R175) [[4]](diffhunk://#diff-e64147aac41e73953d455d654d86f980415e855f29db5503a3f31e2008e23fb4L230-R227) [[5]](diffhunk://#diff-e64147aac41e73953d455d654d86f980415e855f29db5503a3f31e2008e23fb4L273-R269) [[6]](diffhunk://#diff-e64147aac41e73953d455d654d86f980415e855f29db5503a3f31e2008e23fb4L283-R278) [[7]](diffhunk://#diff-e64147aac41e73953d455d654d86f980415e855f29db5503a3f31e2008e23fb4L316-R310) [[8]](diffhunk://#diff-e64147aac41e73953d455d654d86f980415e855f29db5503a3f31e2008e23fb4L348-R341) [[9]](diffhunk://#diff-e64147aac41e73953d455d654d86f980415e855f29db5503a3f31e2008e23fb4L360-R352) [[10]](diffhunk://#diff-e64147aac41e73953d455d654d86f980415e855f29db5503a3f31e2008e23fb4L392-R383) [[11]](diffhunk://#diff-e64147aac41e73953d455d654d86f980415e855f29db5503a3f31e2008e23fb4L402-R392) [[12]](diffhunk://#diff-e64147aac41e73953d455d654d86f980415e855f29db5503a3f31e2008e23fb4L432-R421) [[13]](diffhunk://#diff-e64147aac41e73953d455d654d86f980415e855f29db5503a3f31e2008e23fb4L462-R450) [[14]](diffhunk://#diff-e64147aac41e73953d455d654d86f980415e855f29db5503a3f31e2008e23fb4L474-R461)

### Addition of `ERC20ApprovePolicy` test suite:
* Introduced a new file `test/erc20ApprovePolicy.spec.ts` with comprehensive tests for the `ERC20ApprovePolicy`. It includes scenarios for:
  - Allowing approvals for configured spenders.
  - Rejecting approvals for unconfigured spenders.
  - Rejecting non-approve transactions.
  - Allowing zero-amount approvals for unconfigured spenders.
  - Validating that only ERC20 approve transactions and `CALL` operations can be configured.