### PR TITLE
ERC20 Transfer Policy Test

### DIFF
--- a/test/erc20ApprovePolicy.spec.ts
+++ b/test/erc20ApprovePolicy.spec.ts
@@ -101,7 +101,7 @@ describe('ERC20ApprovePolicy', function () {
       const spender = randomAddress()
       const amount = ethers.parseEther('100')
 
-      // Configure the ERC20 approve policy with no signer
+      // Configure the ERC20 approve policy with no spender
       const spenderData: { spender: string; allowed: boolean }[] = []
 
       const configurations = [

--- a/test/erc20ApprovePolicy.spec.ts
+++ b/test/erc20ApprovePolicy.spec.ts
@@ -102,12 +102,7 @@ describe('ERC20ApprovePolicy', function () {
       const amount = ethers.parseEther('100')
 
       // Configure the ERC20 approve policy with no signer
-      const spenderData = [
-        {
-          spender: ZeroAddress,
-          allowed: false
-        }
-      ]
+      const spenderData: { spender: string; allowed: boolean }[] = []
 
       const configurations = [
         createConfiguration({
@@ -201,13 +196,8 @@ describe('ERC20ApprovePolicy', function () {
       const spender = randomAddress()
       const amount = ethers.parseEther('1')
 
-      // Configure the ERC20 approve policy with a different spender
-      const spenderData = [
-        {
-          spender: ZeroAddress,
-          allowed: false
-        }
-      ]
+      // Configure the ERC20 approve policy with no spender
+      const spenderData: { spender: string; allowed: boolean }[] = []
 
       const configurations = [
         createConfiguration({

--- a/test/erc20TransferPolicy.spec.ts
+++ b/test/erc20TransferPolicy.spec.ts
@@ -1,0 +1,317 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
+import { expect } from 'chai'
+import { ZeroAddress } from 'ethers'
+import { ethers } from 'hardhat'
+
+import { createConfiguration, createSafe, execTransaction, randomAddress, SafeOperation } from '../src/utils'
+import { deploySafeContracts, deploySafePolicyGuard, deployERC20TransferPolicy, deployTestERC20Token } from './deploy'
+
+describe('ERC20TransferPolicy', function () {
+  async function fixture() {
+    const [, owner, recipient, other] = await ethers.getSigners()
+
+    // Deploy the SafePolicyGuard contract
+    const { safePolicyGuard } = await deploySafePolicyGuard()
+
+    // Deploy the Safe contracts
+    const { safeProxyFactory, safe: safeSingleton } = await deploySafeContracts()
+    const safe = await createSafe({
+      owner,
+      guard: ZeroAddress, // No guard at this point
+      saltNonce: BigInt(0x4),
+      safeProxyFactory,
+      singleton: safeSingleton
+    })
+
+    // Deploy ERC20TransferPolicy contract
+    const { erc20TransferPolicy } = await deployERC20TransferPolicy()
+
+    // Deploy Test ERC20 Token contract
+    const { token } = await deployTestERC20Token()
+
+    // Mint some tokens to the Safe
+    await token.mint(await safe.getAddress(), ethers.parseEther('1000'))
+
+    return {
+      owner,
+      recipient,
+      other,
+      safe,
+      safePolicyGuard,
+      erc20TransferPolicy,
+      token
+    }
+  }
+
+  describe('Integration with SafePolicyGuard', function () {
+    it('Should allow transfer to configured recipient', async function () {
+      const { owner, recipient, safePolicyGuard, safe, erc20TransferPolicy, token } = await loadFixture(fixture)
+
+      const amount = ethers.parseEther('100')
+
+      // Configure the ERC20 transfer policy
+      const recipientData = [
+        {
+          recipient: await recipient.getAddress(),
+          allowed: true
+        }
+      ]
+
+      const configurations = [
+        createConfiguration({
+          target: await token.getAddress(),
+          selector: token.interface.getFunction('transfer').selector,
+          policy: await erc20TransferPolicy.getAddress(),
+          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address recipient, bool allowed)[]'], [recipientData])
+        })
+      ]
+
+      // Configure the policy
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
+      })
+
+      // Enable the guard on safe
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+      })
+
+      // Execute the transfer transaction
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await token.getAddress(),
+        data: token.interface.encodeFunctionData('transfer', [await recipient.getAddress(), amount])
+      })
+
+      // Verify the transfer was successful
+      expect(await token.balanceOf(await recipient.getAddress())).to.equal(amount)
+    })
+
+    it('Should not allow transfer to unconfigured recipient', async function () {
+      const { owner, other, safePolicyGuard, safe, erc20TransferPolicy, token } = await loadFixture(fixture)
+
+      const amount = ethers.parseEther('100')
+
+      // Configure the ERC20 transfer policy with no recipients
+      const recipientData: { recipient: string; allowed: boolean }[] = []
+
+      const configurations = [
+        createConfiguration({
+          target: await token.getAddress(),
+          selector: token.interface.getFunction('transfer').selector,
+          policy: await erc20TransferPolicy.getAddress(),
+          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address recipient, bool allowed)[]'], [recipientData])
+        })
+      ]
+
+      // Configure the policy
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
+      })
+
+      // Enable the guard on safe
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+      })
+
+      // Try to execute a transfer transaction to unconfigured recipient
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: await token.getAddress(),
+          data: token.interface.encodeFunctionData('transfer', [await other.getAddress(), amount])
+        })
+      ).to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
+    })
+
+    it('Should not allow non-transfer transactions', async function () {
+      const { owner, recipient, safePolicyGuard, safe, erc20TransferPolicy, token } = await loadFixture(fixture)
+
+      const amount = ethers.parseEther('100')
+
+      // Configure the ERC20 transfer policy
+      const recipientData = [
+        {
+          recipient: await recipient.getAddress(),
+          allowed: true
+        }
+      ]
+
+      const configurations = [
+        createConfiguration({
+          target: await token.getAddress(),
+          selector: token.interface.getFunction('transfer').selector,
+          policy: await erc20TransferPolicy.getAddress(),
+          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address recipient, bool allowed)[]'], [recipientData])
+        })
+      ]
+
+      // Configure the policy
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
+      })
+
+      // Enable the guard on safe
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+      })
+
+      // Try to execute an approve transaction (non-transfer)
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: await token.getAddress(),
+          data: token.interface.encodeFunctionData('approve', [await recipient.getAddress(), amount])
+        })
+      ).to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
+    })
+
+    it('Should allow transferFrom to configured recipient', async function () {
+      const { owner, recipient, safePolicyGuard, safe, erc20TransferPolicy, token } = await loadFixture(fixture)
+
+      const amount = ethers.parseEther('100')
+
+      // Mint tokens to the owner
+      await token.mint(await owner.getAddress(), amount)
+
+      // Configure the ERC20 transfer policy
+      const recipientData = [
+        {
+          recipient: await recipient.getAddress(),
+          allowed: true
+        }
+      ]
+
+      const configurations = [
+        createConfiguration({
+          target: await token.getAddress(),
+          selector: token.interface.getFunction('transferFrom').selector,
+          policy: await erc20TransferPolicy.getAddress(),
+          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address recipient, bool allowed)[]'], [recipientData])
+        })
+      ]
+
+      // Configure the policy
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
+      })
+
+      // Enable the guard on safe
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+      })
+
+      // Approve the Safe to spend tokens (using owner's signer)
+      await token.connect(owner).approve(await safe.getAddress(), amount)
+
+      // Execute the transferFrom transaction
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await token.getAddress(),
+        data: token.interface.encodeFunctionData('transferFrom', [
+          await owner.getAddress(),
+          await recipient.getAddress(),
+          amount
+        ])
+      })
+
+      // Verify the transfer was successful
+      expect(await token.balanceOf(await recipient.getAddress())).to.equal(amount)
+    })
+  })
+
+  describe('Policy Configuration', function () {
+    it('Should only be able to configure ERC20 transfer transactions', async function () {
+      const { owner, safePolicyGuard, safe, erc20TransferPolicy, token } = await loadFixture(fixture)
+
+      // Configure the ERC20 transfer policy
+      const recipientData = [
+        {
+          recipient: randomAddress(),
+          allowed: true
+        }
+      ]
+
+      // Trying to configure a non-transfer transaction
+      const configurations = [
+        createConfiguration({
+          target: await token.getAddress(),
+          selector: token.interface.getFunction('approve').selector, // Non-transfer function
+          policy: await erc20TransferPolicy.getAddress(),
+          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address recipient, bool allowed)[]'], [recipientData])
+        })
+      ]
+
+      // Configure the policy
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: await safePolicyGuard.getAddress(),
+          data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
+        })
+      ).to.be.revertedWithCustomError(erc20TransferPolicy, 'InvalidSelector')
+    })
+
+    it('Should only allow CALL operations', async function () {
+      const { owner, safePolicyGuard, safe, erc20TransferPolicy, token } = await loadFixture(fixture)
+
+      // Configure the ERC20 transfer policy
+      const recipientData = [
+        {
+          recipient: randomAddress(),
+          allowed: true
+        }
+      ]
+
+      // Trying to configure with DELEGATECALL operation
+      const configurations = [
+        createConfiguration({
+          target: await token.getAddress(),
+          selector: token.interface.getFunction('transfer').selector,
+          operation: SafeOperation.DelegateCall,
+          policy: await erc20TransferPolicy.getAddress(),
+          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address recipient, bool allowed)[]'], [recipientData])
+        })
+      ]
+
+      // Configure the policy
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: await safePolicyGuard.getAddress(),
+          data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
+        })
+      ).to.be.revertedWithCustomError(erc20TransferPolicy, 'InvalidOperation')
+    })
+  })
+})


### PR DESCRIPTION
## TLDR
- Added ERC20 Transfer Policy Test
- Small refactoring in a test

## LLM Description
This pull request includes updates to the `ERC20ApprovePolicy` tests and introduces a comprehensive suite of tests for the new `ERC20TransferPolicy`. The changes improve the test coverage and ensure stricter validation of ERC20 transfer and approval policies.

### Updates to `ERC20ApprovePolicy` tests:

* **Refactored spender data initialization**: Simplified the initialization of `spenderData` in two test cases by replacing hardcoded configurations with an empty array. This ensures consistency and clarity in test setup. [[1]](diffhunk://#diff-be5316f2820c284f3bd904889200593fbd5ed2fc8741c3e74a6bf3e0980b8a5fL105-R105) [[2]](diffhunk://#diff-be5316f2820c284f3bd904889200593fbd5ed2fc8741c3e74a6bf3e0980b8a5fL204-R200)

### New `ERC20TransferPolicy` tests:

* **Integration tests with `SafePolicyGuard`**: Added tests to validate the integration of `ERC20TransferPolicy` with `SafePolicyGuard`, ensuring correct behavior for allowed and disallowed transfers, as well as non-transfer transactions.
* **Policy configuration validation**: Introduced tests to ensure that only valid configurations are accepted, such as rejecting non-transfer functions and disallowing operations other than `CALL`.
* **Comprehensive test setup**: Implemented a reusable `fixture` to deploy and initialize all necessary contracts, streamlining the test setup and improving maintainability.