### PR TITLE
Check Transaction as `view` function

### DIFF
--- a/contracts/SafePolicyGuard.sol
+++ b/contracts/SafePolicyGuard.sol
@@ -111,7 +111,7 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
         uint256 value,
         bytes calldata data,
         Operation operation
-    ) internal returns (bool) {
+    ) internal view returns (bool) {
         bytes4 selector = _decodeSelector(data);
 
         // Invalidate Root
@@ -144,7 +144,7 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
         address payable,
         bytes calldata signatures,
         address
-    ) external override {
+    ) external view override {
         // TODO(nlordell): To simplify policies, we do not support gas prices for transaction
         // execution payment. This would add another mechanism for extracting funds from a Safe
         // transaction that is rarely used, and therefore should not be covered by the access
@@ -174,7 +174,7 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
         bytes calldata data,
         Operation operation,
         address
-    ) external override returns (bytes32 moduleTxHash) {
+    ) external view override returns (bytes32 moduleTxHash) {
         checkTransaction(msg.sender, to, value, data, operation, _emptyContext());
         return bytes32(0);
     }

--- a/contracts/core/PolicyEngine.sol
+++ b/contracts/core/PolicyEngine.sol
@@ -104,7 +104,7 @@ abstract contract PolicyEngine is IPolicyEngine {
         bytes calldata data,
         Operation operation,
         bytes calldata context
-    ) public returns (address) {
+    ) public view returns (address) {
         (AccessSelector.T access, address policy) = getPolicy(safe, to, data, operation);
         require(policy != address(0), AccessDenied(address(0)));
         try IPolicy(policy).checkTransaction(safe, to, value, data, operation, context, access) returns (

--- a/contracts/interfaces/IPolicy.sol
+++ b/contracts/interfaces/IPolicy.sol
@@ -27,7 +27,7 @@ interface IPolicy {
         Operation operation,
         bytes calldata context,
         AccessSelector.T access
-    ) external returns (bytes4 magicValue);
+    ) external view returns (bytes4 magicValue);
 
     /**
      * @notice Configures the policy.

--- a/contracts/interfaces/IPolicyEngine.sol
+++ b/contracts/interfaces/IPolicyEngine.sol
@@ -41,5 +41,5 @@ interface IPolicyEngine {
         bytes calldata data,
         Operation operation,
         bytes calldata context
-    ) external returns (address);
+    ) external view returns (address);
 }

--- a/contracts/policies/MultiSendPolicy.sol
+++ b/contracts/policies/MultiSendPolicy.sol
@@ -23,7 +23,7 @@ contract MultiSendPolicy is IPolicy {
         Operation operation,
         bytes calldata context,
         AccessSelector.T
-    ) external override returns (bytes4 magicValue) {
+    ) external view override returns (bytes4 magicValue) {
         bytes calldata transactions = _decodeMultiSendTransactions(data);
         bytes calldata ctx;
         while (transactions.length > 0) {

--- a/contracts/test/MockPolicy.sol
+++ b/contracts/test/MockPolicy.sol
@@ -43,7 +43,7 @@ contract MockPolicy is IPolicy {
         Operation,
         bytes calldata,
         AccessSelector.T
-    ) external override returns (bytes4 magicValue) {
+    ) external view override returns (bytes4 magicValue) {
         return revertTransaction ? magicValue : IPolicy.checkTransaction.selector;
     }
 


### PR DESCRIPTION
# TLDR
- Making `checkTransaction(...)` as a static view function. 

# LLM Description
This pull request introduces a series of changes to ensure that functions across multiple contracts and interfaces are marked with the `view` modifier where applicable. These updates enhance clarity and enforce the immutability of functions that do not modify the state. The changes primarily affect the `SafePolicyGuard`, `PolicyEngine`, `IPolicy`, and related contracts and interfaces.

### Updates to Function Modifiers:

#### SafePolicyGuard Contract:
* Updated the `checkTransaction` function to include the `view` modifier, ensuring it is treated as a read-only function. (`contracts/SafePolicyGuard.sol`, [contracts/SafePolicyGuard.solL114-R114](diffhunk://#diff-eb79142b3e8c4c9e9f789b0da92aa657ad12ba14b016b012e25cc95f7e23458eL114-R114))
* Modified the `checkTransaction` external function to use the `view` modifier for consistency and clarity. (`contracts/SafePolicyGuard.sol`, [contracts/SafePolicyGuard.solL147-R147](diffhunk://#diff-eb79142b3e8c4c9e9f789b0da92aa657ad12ba14b016b012e25cc95f7e23458eL147-R147))
* Updated the `checkTransaction` function returning `bytes32 moduleTxHash` to include the `view` modifier. (`contracts/SafePolicyGuard.sol`, [contracts/SafePolicyGuard.solL177-R177](diffhunk://#diff-eb79142b3e8c4c9e9f789b0da92aa657ad12ba14b016b012e25cc95f7e23458eL177-R177))

#### PolicyEngine Contract:
* Updated the `checkTransaction` function to use the `view` modifier, reflecting its read-only nature. (`contracts/core/PolicyEngine.sol`, [contracts/core/PolicyEngine.solL107-R107](diffhunk://#diff-32c8c89f6cb3379b5b4af273d6737bba00ee437f1f1c3e61cc3526178eb4b829L107-R107))

#### Interfaces:
* Updated the `checkTransaction` function in the `IPolicy` interface to include the `view` modifier. (`contracts/interfaces/IPolicy.sol`, [contracts/interfaces/IPolicy.solL30-R30](diffhunk://#diff-f3b043fd577ee026a3301d9d6433e16c3a8dbcbb33c6236d443b5df399ec32feL30-R30))
* Updated the `getPolicy` function in the `IPolicyEngine` interface to include the `view` modifier. (`contracts/interfaces/IPolicyEngine.sol`, [contracts/interfaces/IPolicyEngine.solL44-R44](diffhunk://#diff-e80219b6640ee34ef47770ec8e370ac805cd54747cd56347db908277ec8ae27dL44-R44))

#### Policies:
* Updated the `checkTransaction` function in the `MultiSendPolicy` contract to include the `view` modifier. (`contracts/policies/MultiSendPolicy.sol`, [contracts/policies/MultiSendPolicy.solL26-R26](diffhunk://#diff-fb77e187f49a944861afd45009ce8058b6b6e7807bf27156470aef2fbe7e9781L26-R26))
* Updated the `checkTransaction` function in the `MockPolicy` contract to include the `view` modifier. (`contracts/test/MockPolicy.sol`, [contracts/test/MockPolicy.solL46-R46](diffhunk://#diff-2b7895e4147a2e752c997037bf75976a3b3d5d9cf66ec48fde15c6b931e547fdL46-R46))