### PR TITLE
Allowed Module Policy

### DIFF
--- a/contracts/SafePolicyGuard.sol
+++ b/contracts/SafePolicyGuard.sol
@@ -173,9 +173,9 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
         uint256 value,
         bytes calldata data,
         Operation operation,
-        address
+        address module
     ) external view override returns (bytes32 moduleTxHash) {
-        checkTransaction(msg.sender, to, value, data, operation, _emptyContext());
+        checkTransaction(msg.sender, to, value, data, operation, abi.encode(module));
         return bytes32(0);
     }
 

--- a/contracts/core/PolicyEngine.sol
+++ b/contracts/core/PolicyEngine.sol
@@ -103,7 +103,7 @@ abstract contract PolicyEngine is IPolicyEngine {
         uint256 value,
         bytes calldata data,
         Operation operation,
-        bytes calldata context
+        bytes memory context
     ) public view returns (address) {
         (AccessSelector.T access, address policy) = getPolicy(safe, to, data, operation);
         require(policy != address(0), AccessDenied(address(0)));

--- a/contracts/interfaces/IPolicyEngine.sol
+++ b/contracts/interfaces/IPolicyEngine.sol
@@ -40,6 +40,6 @@ interface IPolicyEngine {
         uint256 value,
         bytes calldata data,
         Operation operation,
-        bytes calldata context
+        bytes memory context
     ) external view returns (address);
 }

--- a/contracts/policies/AllowedModulePolicy.sol
+++ b/contracts/policies/AllowedModulePolicy.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity =0.8.28;
+
+import {IPolicy, Operation} from "../interfaces/IPolicy.sol";
+import {AccessSelector} from "../libraries/AccessSelector.sol";
+
+/**
+ * @title Allowed Module Policy
+ * @dev Allows any transaction from a particular module.
+ */
+contract AllowedModulePolicy is IPolicy {
+    /**
+     * @notice Mapping of allowed modules for each safe.
+     * @dev The mapping is structured as follows:
+     * - The first key is the address of the policy guard.
+     * - The second key is the address of the safe.
+     * - The third key is the address of the module.
+     * - The value is a boolean indicating whether the module is allowed or not.
+     */
+    mapping(address => mapping(address => mapping(address => bool))) public allowedModules;
+
+    /**
+     * @notice Error indicating that the module is not allowed.
+     */
+    error UnauthorizedModule();
+
+    /**
+     * @notice Error indicating that the module address is invalid.
+     */
+    error InvalidModule();
+
+    /**
+     * @inheritdoc IPolicy
+     * @dev This policy returns the magic value if it is an allowed module.
+     */
+    function checkTransaction(
+        address safe,
+        address,
+        uint256,
+        bytes calldata,
+        Operation,
+        bytes calldata context,
+        AccessSelector.T
+    ) external view override returns (bytes4 magicValue) {
+        address module = abi.decode(context, (address));
+
+        require(allowedModules[msg.sender][safe][module], UnauthorizedModule());
+
+        return IPolicy.checkTransaction.selector;
+    }
+
+    /**
+     * @inheritdoc IPolicy
+     * @dev This policy does not require any configuration.
+     *      QUESTION: Should we allow DELEGATECALLs to be configured?
+     */
+    function configure(address safe, AccessSelector.T, bytes memory data) external override returns (bool) {
+        address module = abi.decode(data, (address));
+
+        allowedModules[msg.sender][safe][module] = true;
+
+        return true;
+    }
+}

--- a/contracts/test/MockPolicy.sol
+++ b/contracts/test/MockPolicy.sol
@@ -51,7 +51,7 @@ contract MockPolicy is IPolicy {
      * @inheritdoc IPolicy
      * @dev This policy does not require any configuration.
      */
-    function configure(address, AccessSelector.T, bytes memory) external override returns (bool) {
+    function configure(address, AccessSelector.T, bytes memory) external view override returns (bool) {
         return !revertConfigure;
     }
 }

--- a/test/deploy/AllowedModulePolicy.ts
+++ b/test/deploy/AllowedModulePolicy.ts
@@ -1,0 +1,21 @@
+import { ContractRunner } from 'ethers'
+import { ethers } from 'hardhat'
+
+import { AllowedModulePolicy } from '../../typechain-types'
+import { deterministicDeployment } from './util/create2'
+
+export type DeployOptions =
+  | {
+      runner?: ContractRunner
+    }
+  | undefined
+
+export async function deploy({ runner }: DeployOptions = {}) {
+  const allowedModulePolicyFactory = await ethers.getContractFactory('AllowedModulePolicy')
+  const factory = runner ? allowedModulePolicyFactory.connect(runner) : allowedModulePolicyFactory
+  const allowedModulePolicy = (await deterministicDeployment(factory, [])) as unknown as AllowedModulePolicy
+
+  return {
+    allowedModulePolicy
+  }
+}

--- a/test/deploy/index.ts
+++ b/test/deploy/index.ts
@@ -1,6 +1,7 @@
 export { deploy as deploySafeContracts } from './SafeContracts'
 export { deploy as deploySafePolicyGuard } from './SafePolicyGuard'
 export { deploy as deployAllowPolicy } from './AllowPolicy'
+export { deploy as deployAllowedModulePolicy } from './AllowedModulePolicy'
 export { deploy as deployERC20ApprovePolicy } from './ERC20ApprovePolicy'
 export { deploy as deployERC20TransferPolicy } from './ERC20TransferPolicy'
 export { deploy as deployNativeTransferPolicy } from './NativeTransferPolicy'


### PR DESCRIPTION
# TLDR
- Created new Allowed Module Policy
- Deployment script for the same

# LLM Description
This pull request introduces a new `AllowedModulePolicy` contract, updates the handling of `context` parameters in several contracts, and adds deployment scripts and tests for the new policy. These changes enhance modularity and improve the flexibility of transaction validation.

### New Policy Implementation:
* Added the `AllowedModulePolicy` contract, which allows transactions from specific modules. It includes a mapping for allowed modules, error definitions, and methods for transaction validation and configuration. (`contracts/policies/AllowedModulePolicy.sol`)

### Parameter Handling Updates:
* Changed the `context` parameter type from `bytes calldata` to `bytes memory` in the `PolicyEngine` and `IPolicyEngine` contracts to improve compatibility and flexibility. (`contracts/core/PolicyEngine.sol`, `contracts/interfaces/IPolicyEngine.sol`) [[1]](diffhunk://#diff-32c8c89f6cb3379b5b4af273d6737bba00ee437f1f1c3e61cc3526178eb4b829L106-R106) [[2]](diffhunk://#diff-e80219b6640ee34ef47770ec8e370ac805cd54747cd56347db908277ec8ae27dL43-R43)

### Integration with SafePolicyGuard:
* Updated the `SafePolicyGuard` contract to pass the module address in the `context` parameter when calling `checkTransaction`. (`contracts/SafePolicyGuard.sol`)

### Deployment Enhancements:
* Added a deployment script for the `AllowedModulePolicy` contract to enable deterministic deployments. (`test/deploy/AllowedModulePolicy.ts`, `test/deploy/index.ts`) [[1]](diffhunk://#diff-31e0047ea4a5308fecd5c9f9fdd89999a7cab002fcbce3667e675e8c4bc83b27R1-R21) [[2]](diffhunk://#diff-2e8c2bc24d2a0b822af851a46dec64b5740f1b49b2a0f2d603475c4c5dd67eb8R4)

### Testing Adjustments:
* Modified the `MockPolicy` contract to make the `configure` function a `view` function, reflecting its read-only nature. (`contracts/test/MockPolicy.sol`)